### PR TITLE
adding guard for custom element registration

### DIFF
--- a/src/jinn-codemirror.ts
+++ b/src/jinn-codemirror.ts
@@ -399,4 +399,6 @@ export class JinnCodemirror extends HTMLElement {
     }
 }
 
-window.customElements.define('jinn-codemirror', JinnCodemirror);
+if (!customElements.get('jinn-codemirror')) {
+    window.customElements.define('jinn-codemirror', JinnCodemirror);
+}


### PR DESCRIPTION
preventing jinn-codemirror from being registered twice